### PR TITLE
Add delta frame and histogram equalisation features to main

### DIFF
--- a/include/multi_cam_detect.hpp
+++ b/include/multi_cam_detect.hpp
@@ -61,7 +61,7 @@ namespace mcmt {
 	Json::Value detections_2d_(Json::arrayValue);
 
 	// declare detection and tracking functions
-	cv::Mat initialize_cameras();
+	std::vector<cv::Mat> initialize_cameras();
 	void frame_to_frame_subtraction(std::shared_ptr<Camera> & camera);
 	void apply_env_compensation(std::shared_ptr<Camera> & camera);
 	cv::Mat apply_bg_subtractions(std::shared_ptr<Camera> & camera, int frame_id);
@@ -91,7 +91,7 @@ namespace mcmt {
 	/**
 	 * Constants, variable and functions definition
 	 */
-	cv::Mat initialize_cameras() {
+	std::vector<cv::Mat> initialize_cameras() {
 
 		std::string vid_input, vid_output;
 
@@ -119,13 +119,17 @@ namespace mcmt {
 			
 		}
 
+		std::vector<cv::Mat> sample_frames;
 		cv::Mat sample_frame;
-		cameras_[0]->cap_ >> sample_frame;
-
+		for (int cam_idx = 0; cam_idx < NUM_OF_CAMERAS_; cam_idx++) {
+			cameras_[cam_idx]->cap_ >> sample_frame;
+			sample_frames.push_back(sample_frame);
+		}
+		
 		// initialize kernel used for morphological transformations
 		element_ = cv::getStructuringElement(0, cv::Size(5, 5));
 
-		return sample_frame;
+		return sample_frames;
 	}
 
 	/**

--- a/include/multi_cam_detect.hpp
+++ b/include/multi_cam_detect.hpp
@@ -146,7 +146,7 @@ namespace mcmt {
 			cv::bitwise_not(frame_delta_grayscale_, frame_delta_grayscale_);
 			cv::cvtColor(frame_delta_grayscale_, frame_delta_, CV_GRAY2RGB);
 
-			double alpha = 0.75;
+			double alpha = 0.85;
    			cv::addWeighted(frame_delta_, alpha, camera->frame_, 1.0 - alpha, 0.0, camera->frame_);
 	}
 
@@ -317,6 +317,51 @@ namespace mcmt {
 
 		// draw contours on masked frame to remove background
 		cv::drawContours(camera->masked_[masked_id], background_contours, -1, cv::Scalar(0, 0, 0), -1);
+
+		// cv::Mat bg_mask;
+		// cv::Mat fg_mask = camera->frame_original_.clone();
+		// cv::drawContours(fg_mask, background_contours, -1, cv::Scalar(0, 0, 0), -1);
+		// cv::absdiff(fg_mask, camera->frame_original_, bg_mask);
+
+		// cv::Mat bg_mask_store = camera->frame_store_.clone();
+		// cv::drawContours(bg_mask_store, background_contours, -1, cv::Scalar(0, 0, 0), -1);
+		// cv::absdiff(bg_mask_store, camera->frame_store_, bg_mask_store);
+
+		// cv::Mat frame_delta_, frame_delta_grayscale_;
+		// cv::absdiff(bg_mask, bg_mask_store, frame_delta_);
+
+		// cv::cvtColor(frame_delta_, frame_delta_grayscale_, CV_BGR2GRAY);
+		// cv::bitwise_not(frame_delta_grayscale_, frame_delta_grayscale_);
+		// cv::cvtColor(frame_delta_grayscale_, frame_delta_, CV_GRAY2RGB);
+		// cv::Mat frame_delta_temp_ = frame_delta_.clone();
+		// cv::drawContours(frame_delta_, background_contours, -1, cv::Scalar(0, 0, 0), -1);
+		// cv::absdiff(frame_delta_, frame_delta_temp_, frame_delta_);
+
+		// cv::imshow("Frame Delta " + std::to_string(masked_id), frame_delta_);
+
+		// double alpha = 0.75;
+   		// cv::addWeighted(frame_delta_, alpha, bg_mask, 1.0 - alpha, 0.0, bg_mask);
+
+		// cv::imshow("FG Mask " + std::to_string(masked_id), fg_mask);
+
+		// cv::Mat bg_augmented_mat;
+		// cv::addWeighted(fg_mask, 1.0, bg_mask, 1.0, 0.0, bg_augmented_mat);
+
+		// cv::imshow("BG Augmented " + std::to_string(masked_id), bg_augmented_mat);
+		// // cv::imshow("BG Subtracted " + std::to_string(masked_id), camera->masked_[masked_id]);
+		// // cv::imshow("BG Contour " + std::to_string(masked_id), bg_removed);
+
+		// cv::Mat masked, converted_mask;
+		
+
+		// cv::convertScaleAbs(frame_delta_, masked);
+		// // cv::convertScaleAbs(masked, masked, 1, (256 - average_brightness(camera) + BRIGHTNESS_GAIN_));
+		
+		// // subtract background
+		// camera->fgbg_[masked_id]->apply(masked, masked, FGBG_LEARNING_RATE_);
+		// masked.convertTo(converted_mask, CV_8UC1);
+		// cv::imshow("Converted Mask " + std::to_string(masked_id), converted_mask);
+
 		return bg_removed;
 	}
 

--- a/include/multi_cam_detect.hpp
+++ b/include/multi_cam_detect.hpp
@@ -142,9 +142,9 @@ namespace mcmt {
 			cv::Mat frame_delta_, frame_delta_grayscale_;
 			cv::absdiff(camera->frame_, camera->frame_store_, frame_delta_);
 
-			cv::cvtColor(frame_delta_, frame_delta_grayscale_, CV_BGR2GRAY);
+			cv::cvtColor(frame_delta_, frame_delta_grayscale_, cv::COLOR_BGR2GRAY);
 			cv::bitwise_not(frame_delta_grayscale_, frame_delta_grayscale_);
-			cv::cvtColor(frame_delta_grayscale_, frame_delta_, CV_GRAY2RGB);
+			cv::cvtColor(frame_delta_grayscale_, frame_delta_, cv::COLOR_GRAY2BGR);
 
 			double alpha = 0.85;
    			cv::addWeighted(frame_delta_, alpha, camera->frame_, 1.0 - alpha, 0.0, camera->frame_);

--- a/include/multi_cam_detect.hpp
+++ b/include/multi_cam_detect.hpp
@@ -211,6 +211,15 @@ namespace mcmt {
     	}
 		cv::cvtColor(sky, sky, cv::COLOR_HSV2BGR);
 
+		// Treeline (non-sky) enhancements using histogram equalisation on intensity channel
+		channels.clear();
+		cv::Mat ycrcb;
+		cv::cvtColor(non_sky, ycrcb, cv::COLOR_BGR2YCrCb);
+		cv::split(ycrcb, channels);
+		cv::equalizeHist(channels[0], channels[0]);
+		cv::merge(channels, ycrcb);
+		cv::cvtColor(ycrcb, non_sky, cv::COLOR_YCrCb2BGR);
+
 		// Recombine the sky and treeline
 		cv::add(sky, non_sky, camera->frame_ec_);
 		// cv::imshow("After sun compensation", camera->frame_ec_);

--- a/include/multi_cam_detect_utils.hpp
+++ b/include/multi_cam_detect_utils.hpp
@@ -102,7 +102,7 @@ namespace mcmt {
 
 			// declare video parameters
 			cv::VideoCapture cap_;
-			cv::Mat frame_, frame_ec_, gray_, frame_store_;
+			cv::Mat frame_, frame_original_, frame_ec_, gray_, frame_store_;
 			std::array<cv::Mat, 2> masked_, removebg_;
 			std::string video_input_;
 			int cam_index_, frame_w_, frame_h_, fps_, next_id_;

--- a/include/multi_cam_detect_utils.hpp
+++ b/include/multi_cam_detect_utils.hpp
@@ -102,7 +102,7 @@ namespace mcmt {
 
 			// declare video parameters
 			cv::VideoCapture cap_;
-			cv::Mat frame_, frame_ec_, gray_;
+			cv::Mat frame_, frame_ec_, gray_, frame_store_;
 			std::array<cv::Mat, 2> masked_, removebg_;
 			std::string video_input_;
 			int cam_index_, frame_w_, frame_h_, fps_, next_id_;

--- a/include/multi_cam_params.hpp
+++ b/include/multi_cam_params.hpp
@@ -62,7 +62,11 @@ namespace mcmt {
     const int SECONDARY_FILTER_ = 2;
     const float SEC_FILTER_DELAY_ = 1.0;
 
+    // declare environment compensation parameters
+    const bool USE_HIST_EQUALISE = false;
+
 	// declare background subtractor parameters
+    const bool USE_BG_SUBTRACTOR = false;
     const int FGBG_HISTORY_ = 5;
     const float BACKGROUND_RATIO_ = 0.05;
     const int NMIXTURES_ = 5;

--- a/include/multi_cam_params.hpp
+++ b/include/multi_cam_params.hpp
@@ -38,12 +38,12 @@ namespace mcmt {
 
 	// declare filepaths
 	const bool IS_REALTIME_ = false;
-    const int NUM_OF_CAMERAS_ = 2;
-    const std::string VIDEO_INPUT_1_ = "data/input/E.avi";
+    const int NUM_OF_CAMERAS_ = 1;
+    const std::string VIDEO_INPUT_1_ = "data/input/easybuilding_aircamera1.mp4";
     const std::string VIDEO_INPUT_2_ = "data/input/F.avi";
 	const std::string VIDEO_OUTPUT_1_ = "data/output/A_out.avi";
     const std::string VIDEO_OUTPUT_2_ = "data/output/B_out.avi";
-	const std::string VIDEO_OUTPUT_ANNOTATED_ = "data/output/annotated.avi";
+	const std::string VIDEO_OUTPUT_ANNOTATED_ = "data/output/easybuilding_aircamera1.avi";
 	const std::string TARGETS_2D_OUTPUT_ = "data/output/targets_2d_out.json";
     const std::string TARGETS_3D_OUTPUT_ = "data/output/targets_3d_out.json";
     const std::string FRAME_TIME_ = "data/output/frame_time.csv";

--- a/include/multi_cam_params.hpp
+++ b/include/multi_cam_params.hpp
@@ -43,7 +43,7 @@ namespace mcmt {
     const std::string VIDEO_INPUT_2_ = "data/input/F.avi";
 	const std::string VIDEO_OUTPUT_1_ = "data/output/A_out.avi";
     const std::string VIDEO_OUTPUT_2_ = "data/output/B_out.avi";
-	const std::string VIDEO_OUTPUT_ANNOTATED_ = "data/output/easybuilding_aircamera1.avi";
+	const std::string VIDEO_OUTPUT_ANNOTATED_ = "data/output/easybuilding_aircamera1_75%.avi";
 	const std::string TARGETS_2D_OUTPUT_ = "data/output/targets_2d_out.json";
     const std::string TARGETS_3D_OUTPUT_ = "data/output/targets_3d_out.json";
     const std::string FRAME_TIME_ = "data/output/frame_time.csv";

--- a/include/multi_cam_track.hpp
+++ b/include/multi_cam_track.hpp
@@ -132,8 +132,10 @@ namespace mcmt {
 		next_id_ = 0;
 
 		// initialize cumulative camera tracks
-		cumulative_tracks_[0] = std::shared_ptr<CameraTracks>(new CameraTracks(0));
-		cumulative_tracks_[1] = std::shared_ptr<CameraTracks>(new CameraTracks(1));
+		for (int cam_idx = 0; cam_idx < NUM_OF_CAMERAS_; cam_idx++) {
+			cumulative_tracks_[cam_idx] = std::shared_ptr<CameraTracks>(new CameraTracks(cam_idx));
+			cumulative_tracks_[cam_idx] = std::shared_ptr<CameraTracks>(new CameraTracks(cam_idx));
+		}
 
 	}
 

--- a/src/multi_cam.cpp
+++ b/src/multi_cam.cpp
@@ -75,6 +75,8 @@ int main(int argc, char * argv[]) {
 	initialize_tracks(sample_frame);
 	initialize_logs();
 
+	cameras_[0]->cap_ >> cameras_[0]->frame_store_;
+
 	while (true) {
 		
 		auto frame_start = std::chrono::system_clock::now();
@@ -84,6 +86,17 @@ int main(int argc, char * argv[]) {
 
 			// get camera frame
 			camera->cap_ >> camera->frame_;
+
+			cv::Mat frame_delta_;
+			cv::absdiff(camera->frame_, camera->frame_store_, frame_delta_);
+
+			camera->frame_store_ = camera->frame_;
+
+			std::cout << cv::sum(frame_delta_) << std::endl;
+
+			imshow_resized("Test", frame_delta_);
+
+			camera->frame_ = frame_delta_;
 
 			// check if getting frame was successful
 			if (camera->frame_.empty()) {
@@ -152,6 +165,7 @@ int main(int argc, char * argv[]) {
 			std::cout << "Total number of tracks in camera " << camera->cam_index_ << ": " << camera->tracks_.size() << std::endl;
 
 			log_2D();
+
 		}
 
 		if (is_disconnected_) {

--- a/src/multi_cam.cpp
+++ b/src/multi_cam.cpp
@@ -71,11 +71,13 @@ int main(int argc, char * argv[]) {
 	frame_count_ = 1;
 	bool is_disconnected_ = false;
 
-	cv::Mat sample_frame = initialize_cameras();
-	initialize_tracks(sample_frame);
+	std::vector<cv::Mat> sample_frames = initialize_cameras();
+	initialize_tracks(sample_frames[0]);
 	initialize_logs();
 
-	cameras_[0]->cap_ >> cameras_[0]->frame_store_;
+	for (int cam_idx = 0; cam_idx < NUM_OF_CAMERAS_; cam_idx++) {
+		cameras_[cam_idx]->cap_ >> cameras_[cam_idx]->frame_store_;
+	}
 
 	while (true) {
 		
@@ -87,7 +89,6 @@ int main(int argc, char * argv[]) {
 			// get camera frame
 			camera->cap_ >> camera->frame_;
 			camera->frame_original_ = camera->frame_.clone();
-
 
 			// check if getting frame was successful
 			if (camera->frame_.empty()) {
@@ -242,7 +243,7 @@ int main(int argc, char * argv[]) {
 		std::chrono::duration<float> elapsed_seconds = frame_end - frame_start;
 		std::cout << "Total frame took: " << elapsed_seconds.count() << "s\n";
 
-		graphical_UI(combined_frame, cumulative_tracks_, sample_frame.size(), 1.0 / elapsed_seconds.count());
+		graphical_UI(combined_frame, cumulative_tracks_, sample_frames[0].size(), 1.0 / elapsed_seconds.count());
 	
 		frame_time_file << detect_elapsed_seconds.count() << ", " << track_elapsed_seconds.count() << ", " << elapsed_seconds.count() << "\n"; 
 


### PR DESCRIPTION
These features help to easily detect the target when it goes below the treeline by

1. Delta frame: Detect moving objects in the frame using image subtraction techniques
2. Histogram equalisation: Stretching the intensity histogram of the treeline segment of the frame to improve contrast in that region

Background subtractors and histogram equalisation also have toggles to easily turn them on/off to affect sensitivity of detection