### PR TITLE
Shift from g++ to cmake compile system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ Thumbs.db
 # ignore csv and json data files
 *.csv
 *.json
+
+# CMake build folder
+build/
+
+# spot-it-3d executable
+spot-it-3d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 2.8)
 project( SPOT_IT_3D )
 
 # opencv - specify which version we want to use (e.g. 4.2.0 or 4.5.2?)
-# find_package( OpenCV REQUIRED )
-find_package( OpenCV 4.5.2 REQUIRED )
+find_package( OpenCV 4 REQUIRED )
+# find_package( OpenCV 4.5.2 REQUIRED )
 message(STATUS "Found OpenCV version ${OpenCV_VERSION}")
 include_directories( ${OpenCV_INCLUDE_DIRS} )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+# https://rvarago.medium.com/introduction-to-cmake-for-cpp-4c464272a239
+
+cmake_minimum_required(VERSION 2.8)
+
+# project name
+project( SPOT_IT_3D )
+
+# opencv
+find_package( OpenCV REQUIRED )
+include_directories( ${OpenCV_INCLUDE_DIRS} )
+
+# creates the variable EXEC and sets it to spot-it-3d
+set(EXEC spot-it-3d)
+
+# include headers
+include_directories(include)
+
+# add libraries
+add_subdirectory(lib)
+
+# puts all .cpp files inside src to the SOURCES variable
+file(GLOB SOURCES src/*.cpp)
+
+# compiles the files defined by SOURCES to generate the executable defined by EXEC
+add_executable(${EXEC} ${SOURCES})
+
+# Link executables to libraries
+target_link_libraries( ${EXEC} ${OpenCV_LIBS} )
+target_link_libraries( ${EXEC} PUBLIC Hungarian)
+target_link_libraries( ${EXEC} PUBLIC Json)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,10 @@ cmake_minimum_required(VERSION 2.8)
 # project name
 project( SPOT_IT_3D )
 
-# opencv
-find_package( OpenCV REQUIRED )
+# opencv - specify which version we want to use (e.g. 4.2.0 or 4.5.2?)
+# find_package( OpenCV REQUIRED )
+find_package( OpenCV 4.5.2 REQUIRED )
+message(STATUS "Found OpenCV version ${OpenCV_VERSION}")
 include_directories( ${OpenCV_INCLUDE_DIRS} )
 
 # creates the variable EXEC and sets it to spot-it-3d

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,0 +1,4 @@
+cd build
+cmake ../
+make
+mv spot-it-3d ../

--- a/compile_cmake.sh
+++ b/compile_cmake.sh
@@ -1,3 +1,4 @@
+mkdir -p build
 cd build
 cmake ../
 make

--- a/compile_gcc.sh
+++ b/compile_gcc.sh
@@ -25,16 +25,15 @@ else
 
         # Get OpenCV
         # sudo -s
-        cd /opt
-        git clone https://github.com/Itseez/opencv.git
-        git clone https://github.com/Itseez/opencv_contrib.git
+        cd ~/
+        git clone https://github.com/opencv/opencv.git
+        git clone https://github.com/opencv/opencv_contrib.git
 
         # Build and install OpenCV
-        cd opencv
-        mkdir release
-        cd release
-        sudo cmake -D BUILD_TIFF=ON -D WITH_CUDA=OFF -D ENABLE_AVX=OFF -D WITH_OPENGL=OFF -D WITH_OPENCL=OFF -D WITH_IPP=OFF -D WITH_TBB=ON -D BUILD_TBB=ON -D WITH_EIGEN=OFF -D WITH_V4L=OFF -D WITH_VTK=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D OPENCV_EXTRA_MODULES_PATH=/opt/opencv_contrib/modules /opt/opencv/
-        sudo make -j4
+        mkdir opencv_build
+        cd opencv_build
+        cmake -D BUILD_TIFF=ON -D WITH_CUDA=OFF -D ENABLE_AVX=OFF -D WITH_OPENGL=OFF -D WITH_OPENCL=OFF -D WITH_IPP=OFF -D WITH_TBB=ON -D BUILD_TBB=ON -D WITH_EIGEN=OFF -D WITH_V4L=OFF -D WITH_VTK=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D CMAKE_BUILD_TYPE=RELEASE -D OPENCV_GENERATE_PKGCONFIG=YES -D CMAKE_INSTALL_PREFIX=/usr/local -D OPENCV_EXTRA_MODULES_PATH=../opencv_contrib/modules ../opencv
+        make -j4
         sudo make install
         sudo ldconfig
         cd $dir
@@ -54,5 +53,4 @@ fi
 if [ $opencv_installed == 1 ]
 then
     g++ -I./include -L./lib/hungarian -L./lib/json src/*.cpp lib/hungarian/Hungarian.cpp lib/json/jsoncpp.cpp -o spot-it-3d `pkg-config --cflags --libs opencv4`
-    ./spot-it-3d
 fi

--- a/include/multi_cam_detect_utils.hpp
+++ b/include/multi_cam_detect_utils.hpp
@@ -81,7 +81,7 @@ namespace mcmt {
 
 			// declare dcf variables
 			cv::Ptr<cv::Tracker> tracker_;
-			cv::Rect2d box_;
+			cv::Rect box_;
 	};
 
 	class Camera {

--- a/include/multi_cam_detect_utils.hpp
+++ b/include/multi_cam_detect_utils.hpp
@@ -81,7 +81,11 @@ namespace mcmt {
 
 			// declare dcf variables
 			cv::Ptr<cv::Tracker> tracker_;
-			cv::Rect box_;
+			#if CV_VERSION_MAJOR >= 4 && CV_VERSION_MINOR > 2 // OpenCV 4.5.2 uses cv::Rect
+				cv::Rect box_;
+			#else
+				cv::Rect2d box_;
+			#endif
 	};
 
 	class Camera {

--- a/include/multi_cam_params.hpp
+++ b/include/multi_cam_params.hpp
@@ -38,18 +38,14 @@ namespace mcmt {
 
 	// declare filepaths
 	const bool IS_REALTIME_ = false;
-    const int NUM_OF_CAMERAS_ = 4;
+    const int NUM_OF_CAMERAS_ = 2;
 
     // realtime parameters
-    const std::vector<std::string> VIDEO_INPUT_ = {     "data/input/2-11-WCP_6a_out.avi",
-                                                        "data/input/2-11-WCP_6b_out.avi",
-                                                        "data/input/2-11-WCP_6c_out.avi",
-                                                        "data/input/2-11-WCP_6d_out.avi"
+    const std::vector<std::string> VIDEO_INPUT_ = {     "data/input/munich_5a_raw.avi",
+                                                        "data/input/munich_5b_raw.avi"
                                                     };
     const std::vector<std::string> VIDEO_OUTPUT_ = {    "data/output/3cam_1_out.avi",
-                                                        "data/output/3cam_2_out.avi",
-                                                        "data/output/3cam_3_out.avi",
-                                                        "data/output/3cam_4_out.avi"
+                                                        "data/output/3cam_2_out.avi"
                                                     };
 	const std::string VIDEO_OUTPUT_ANNOTATED_ = "data/output/ABC2.avi";
 	const std::string TARGETS_2D_OUTPUT_ = "data/output/targets_2d_out.json";
@@ -64,8 +60,8 @@ namespace mcmt {
     const bool SHOW_3D_COORDINATES_ = true;
 
 	// declare video parameters
-	const int FRAME_WIDTH_ = 320;
-    const int FRAME_HEIGHT_ = 240;
+	const int FRAME_WIDTH_ = 640;
+    const int FRAME_HEIGHT_ = 480;
     const int VIDEO_FPS_ = 30;
     const int MAX_TOLERATED_CONSECUTIVE_DROPPED_FRAMES_ = 5;
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(Hungarian hungarian/Hungarian.cpp)
+add_library(Json json/jsoncpp.cpp)


### PR DESCRIPTION
This pull request migrates from g++ to cmake compiler. The original gcc compile script, `compile_gcc.sh`, is retained for legacy and backup purposes.

In addition, the Rect/Rect2d issue due to OpenCV versioning is fixed by checking the OpenCV version during compile time. If on OpenCV 4.2.0, cv::Rect2d is used. For 4.5.2, cv::Rect is used