### PR TITLE
Decouple WSrt Edge Computing from main code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(${EXEC} PRIVATE ${GST_LIBRARIES})
 # curl
 find_package( CURL REQUIRED )
 message(STATUS "Found CURL version ${CURL_VERSION_STRING}")
-target_link_libraries( ${EXEC} CURL::libcurl )
+target_link_libraries( ${EXEC} PRIVATE CURL::libcurl )
 
 # add custom include and library folders
 include_directories(${CMAKE_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ file(GLOB SOURCES src/*.cpp)
 # compiles the files defined by SOURCES to generate the executable defined by EXEC
 add_executable(${EXEC} ${SOURCES})
 
+# set WSRT to ON to enable WSrt Edge Camera processing
+# this will activate the macro WSRT_ENABLED to enable all WSrt code
+set(WSRT OFF)
+message(STATUS "WSRT set to ${WSRT}")
+if (WSRT)
+    add_compile_definitions(WSRT_ENABLED)
+endif()
+
 ################################
 # Add dependencies and libraries
 ################################
@@ -53,15 +61,17 @@ target_link_libraries(${EXEC} PUBLIC ${CMAKE_SOURCE_DIR}/lib/wsrt/libsrtreceiver
 target_link_libraries(${EXEC} PUBLIC ${CMAKE_SOURCE_DIR}/lib/wsrt/libwsclient.a)
 
 # add wsrt dependent libraries
-find_library(GOBJECT gobject-2.0)
-target_link_libraries(${EXEC} PUBLIC ${GOBJECT})
-find_library(GLIB glib-2.0)
-target_link_libraries(${EXEC} PUBLIC ${GLIB})
-find_library(PTHREAD pthread)
-target_link_libraries(${EXEC} PUBLIC ${PTHREAD})
-find_library(GSTAPP gstapp-1.0)
-target_link_libraries(${EXEC} PUBLIC ${GSTAPP})
-find_library(TBB tbb)
-target_link_libraries(${EXEC} PUBLIC ${TBB})
-find_library(SOUP soup-2.4)
-target_link_libraries(${EXEC} PUBLIC ${SOUP})
+if (WSRT)
+    find_library(GOBJECT gobject-2.0)
+    target_link_libraries(${EXEC} PUBLIC ${GOBJECT})
+    find_library(GLIB glib-2.0)
+    target_link_libraries(${EXEC} PUBLIC ${GLIB})
+    find_library(PTHREAD pthread)
+    target_link_libraries(${EXEC} PUBLIC ${PTHREAD})
+    find_library(GSTAPP gstapp-1.0)
+    target_link_libraries(${EXEC} PUBLIC ${GSTAPP})
+    find_library(TBB tbb)
+    target_link_libraries(${EXEC} PUBLIC ${TBB})
+    find_library(SOUP soup-2.4)
+    target_link_libraries(${EXEC} PUBLIC ${SOUP})
+endif()

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The following step-by-step processing will guide you on the installation process
 	sudo apt-get install build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
 	sudo apt-get install python3.5-dev python3-numpy libtbb2 libtbb-dev
 	sudo apt-get install libjpeg-dev libpng-dev libtiff5-dev libjasper-dev libdc1394-22-dev libeigen3-dev libtheora-dev libvorbis-dev libxvidcore-dev libx264-dev sphinx-common libtbb-dev yasm libfaac-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenexr-dev libgstreamer-plugins-base1.0-dev libavutil-dev libavfilter-dev libavresample-dev
+	sudo apt install curl && sudo apt-get install libcurl4-openssl-dev
 	```
 	
 	Navigate to any folder of your choice and install Open CV (instructions have been modified from the OpenCV Installation Docs: https://docs.opencv.org/4.5.2/d7/d9f/tutorial_linux_install.html):

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The following step-by-step processing will guide you on the installation process
 	mkdir opencv_build
 	cd opencv_build
 
-	# Configure; note that several flags are toggled for optimisation purposes
+	# Configure; note that several flags are toggled for optimisation purposes (@TODO: Re-activate CUDA?)
 	cmake -D BUILD_TIFF=ON -D WITH_CUDA=OFF -D ENABLE_AVX=OFF -D WITH_OPENGL=OFF -D WITH_OPENCL=OFF -D WITH_IPP=OFF -D WITH_TBB=ON -D BUILD_TBB=ON -D WITH_EIGEN=OFF -D WITH_V4L=ON -D WITH_VTK=OFF -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D CMAKE_BUILD_TYPE=RELEASE -D OPENCV_GENERATE_PKGCONFIG=YES -D CMAKE_INSTALL_PREFIX=/usr/local -D OPENCV_EXTRA_MODULES_PATH=../opencv_contrib/modules ../opencv
 
 	# Build
@@ -126,7 +126,7 @@ The following step-by-step processing will guide you on the installation process
 	pkg-config --modversion opencv4
 	```
 
-	Install the dependencies for the WSrt package as specified [here](Vilota_Wsrt_Guide.md). @TODO: Decouple the WSrt package from the main code so that users who do not need edge computing do not have to install these dependencies
+	**Only if you intend to run WSrt Edge Computing Software**: Install the dependencies for the WSrt package as specified [here](Vilota_Wsrt_Guide.md).
 
 2. Pull spot-it-3d repository from GitHub.
 
@@ -143,27 +143,26 @@ The following step-by-step processing will guide you on the installation process
 4. 	Set the parameters as shown below to your specific setup.
 
 	* Set NUM_OF_CAMERAS_ to the number of cameras in your setup
-	* For non-realtime processing, set IS_REALTIME_ = 0, This processes pre-recorded video files and is meant for research and debugging purposes. The format and location of these files are very specific.
+	* For non-realtime processing, set IS_REALTIME_ = false, This processes pre-recorded video files and is meant for research and debugging purposes. The format and location of these files are very specific.
 		* The location of these video files should be, **relative to the location of this Readme file, placed in "data/input" folder**. The code will only read pre-recorded inputs from this specific folder
 		* **Video input files should be named in the format "<SESSION_NAME_>\_<CAMERA_INPUT_>.<INPUT_FILE_EXTENSION_>"**. 
 		* For example, if you are processing one avi video file originally called "A.avi", rename it as "A_0.avi". Then in the parameteres file, set "A" as your SESSION_NAME_, CAMERA_INPUT_ to {"0"}
 		* If you are processing two avi video files simultaneously (simulating two camera inputs), set the filenames to "A_0.avi", "A_1.avi", and set CAMERA_INPUT_ to {"0", "1"}
-	* For realtime processing with direct USB cameras, set IS_REALTIME_ = 1. This is the usual operating scenario. Specify the camera port numbers directly in CAMERA_INPUT_. You may set SESSION_NAME_ and INPUT_FILE_EXTENSION to any string of your choice (it will be used as the name and file extension of the output files, which will be explained later)
+	* For realtime processing with direct USB cameras, set IS_REALTIME_ = true. This is the usual operating scenario. Specify the camera port numbers directly in CAMERA_INPUT_. You may set SESSION_NAME_ and INPUT_FILE_EXTENSION to any string of your choice (it will be used as the name and file extension of the output files, which will be explained later)
 		* For example, if you have a single USB camera connected to /dev/video0, set CAMERA_INPUT_ = {"0"}
 		* If you have two USB cameras, one connected to /dev/video2 and another to /dev/video4, set CAMERA_INPUT_ = {"2", "4"}
 		* If you are unsure what is your camera port number, type `v4l2-ctl --list-devices` in a separate terminal to bring up the list of media devices connected to your computer.
-	* For realtime processing with vilota edge cameras, set IS_REALTIME_ = 2. This is an experimental setup to test the effectiveness of the code on edge computing. Specify the IP addresses of the edge cameras directly in CAMERA_INPUT_. You may set SESSION_NAME_ and INPUT_FILE_EXTENSION_ to any string of your choice and it will be used as the name and file extension of the output files
-		* For example, if you have two edge cameras on 192.168.1.101 and 192.168.1.102, set CAMERA_INPUT_ = {"192.168.1.101", "192.168.1.102"}
+	* For realtime processing with vilota edge cameras, set the parameters as specified [here](Vilota_Wsrt_Guide.md#Initialise-Client).
 	* Set the video resolution parameters FRAME_WIDTH_ and FRAME_HEIGHT_ to the **exact** video resolution of the input video files (for non-realtime processing), or the **desired** video resolution of the camera inputs (for realtime processing)
 
 	``` cpptools
 	// declare session and camera parameters
     // for the SESSION_NAME_, it is recommended to follow this convention: "YYYY-DD-MM_<location>_<session no>"
-	const int IS_REALTIME_ = 0 // 0 = non realtime processing, 1 = realtime processing with direct USB cameras, 2 = realtime processing for vilota edge cameras ;
-    const int NUM_OF_CAMERAS_ = 2 // 1 for single camera processing, 2 for double camera processing;
     const std::string SESSION_NAME_ = "A" // name of output video file (and input video file for non-realtime processing)
     const std::vector<std::string> CAMERA_INPUT_ = {"0", "1"}; // input locations of cameras
     const std::string INPUT_FILE_EXTENSION_ = "avi"; // input video file extension for non-realtime processing
+	const bool IS_REALTIME_ = false // true = realtime processing
+    const int NUM_OF_CAMERAS_ = 2 // 1 for single camera processing, 2 for double camera processing;
 
 	// declare video parameters
 	const int FRAME_WIDTH_ = 1920;

--- a/Vilota_Wsrt_Guide.md
+++ b/Vilota_Wsrt_Guide.md
@@ -81,12 +81,24 @@ All startup scripts for the edge camera are contained in the "examples" folder
 
 ### Initialise client
 
+Go to the CMakelists.txt file in the base folder of the repository and activate the "WSRT" variable by setting it to "ON". This will activate the WSRT_ENABLED macro in the code:
+
+```
+set(WSRT ON)
+message(STATUS "WSRT set to ${WSRT}")
+if (WSRT)
+    add_compile_definitions(WSRT_ENABLED)
+endif()
+```
+
 Go to the parameters file of the Spot-it-3d code and change the following parameters
 
-- **IS_REALTIME_**: Set to 2
-- **VIDEO_INPUT_**: Set to the IP Addresses of the edge cams
+- **IS_REALTIME_**: Set to True
+- **CAMERA_INPUT_**: Set to the IP Addresses of the edge cams. For example, if you have two edge cameras on 192.168.1.101 and 192.168.1.102, set CAMERA_INPUT_ = {"192.168.1.101", "192.168.1.102"}
 
 Then compile with cmake and run the spot-it-3d executable as usual
+
+> **WARNING**: Setting "WSRT" to "ON" and "IS_REALTIME" to False will lead to undefined behaviour. If you want to run non-realtime videos, always set "WSRT" to "OFF"
 
 ### Troubleshooting
 

--- a/include/WSrtInterface.hpp
+++ b/include/WSrtInterface.hpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2021 Vilota Pte Ltd
 // Author: Huimin C.
 
+#ifdef WSRT_ENABLED
+
 #ifndef WSRTINTERFACE_HPP_
 #define WSRTINTERFACE_HPP_
 
@@ -78,3 +80,5 @@ class WSrt {
 }
 
 #endif          // WSRTINTERFACE_HPP_
+
+#endif          // WSRT_ENABLED

--- a/include/multi_cam_detect.hpp
+++ b/include/multi_cam_detect.hpp
@@ -58,10 +58,11 @@ namespace mcmt {
 
 	// declare detection and tracking functions
 	void initialize_cameras						();
+	void yolo_detection							(std::shared_ptr<Camera> & camera);
 	void apply_env_compensation					(std::shared_ptr<Camera> & camera);
-	void apply_bg_subtractions					(std::shared_ptr<Camera> & camera, int frame_id);
-	void detect_objects							(std::shared_ptr<Camera> & camera);
-	void remove_ground							(std::shared_ptr<Camera> & camera, int masked_id);
+	void simple_background_subtraction			(std::shared_ptr<Camera> & camera);
+	void blob_detection							(std::shared_ptr<Camera> & camera);
+	void contour_detection						(std::shared_ptr<Camera> & camera);
 	void predict_new_locations_of_tracks		(std::shared_ptr<Camera> & camera);
 	void clear_track_variables					(std::shared_ptr<Camera> & camera);
 	void detection_to_track_assignment_KF		(std::shared_ptr<Camera> & camera);
@@ -73,10 +74,6 @@ namespace mcmt {
 	void delete_lost_tracks						(std::shared_ptr<Camera> & camera);
 	void filter_tracks							(std::shared_ptr<Camera> & camera);
 	void close_cameras							();
-
-	void simple_background_subtraction(std::shared_ptr<Camera> & camera);
-	void contour_detection(std::shared_ptr<Camera> & camera);
-	void yolo_detection(std::shared_ptr<Camera> & camera);
 
 	// declare utility functions
 	float euclideanDist(cv::Point2f & p, cv::Point2f & q);

--- a/include/multi_cam_detect_utils.hpp
+++ b/include/multi_cam_detect_utils.hpp
@@ -116,7 +116,9 @@ namespace mcmt {
 
 			// declare video parameters
 			cv::VideoCapture cap_;
-			std::shared_ptr<WSrt> edgecam_cap_; // To remove when interface shifts
+			#if WSRT_ENABLED
+				std::shared_ptr<WSrt> edgecam_cap_; // To remove when interface shifts
+			#endif
 			cv::VideoWriter recording_;
 			cv::Mat frame_, frame_ec_, gray_;
 			std::array<cv::Mat, 2> masked_;

--- a/include/multi_cam_params.hpp
+++ b/include/multi_cam_params.hpp
@@ -37,15 +37,14 @@
 namespace mcmt {  
 
     // declare session and camera parameters
-    // follow convention: "YYYY-DD-MM_<location>_<session no>"
+    // recommended convention for session name: "YYYY-DD-MM_<location>_<session no>"
     // input files should be named in the format "<SESSION_NAME>_<cam no>.<file ext>"
-    // for edge cams (IS_REALTIME_ = 2), specify IP addresses directly in CAMERA_INPUT_. SESSION_NAME_ will be unused
     const std::string SESSION_NAME_ = "test"; 
     const std::vector<std::string> CAMERA_INPUT_ = {"0", "1"};
     const std::string INPUT_FILE_EXTENSION_ = "avi";
-    const int IS_REALTIME_ = 0;
+    const bool IS_REALTIME_ = false; // if WSRT_ENABLED, this must be set to true
     const int NUM_OF_CAMERAS_ = 2;
-    const bool USE_YOLO_DETECTION_ = true;
+    const bool USE_YOLO_DETECTION_ = false;
 
     // declare master switch
     const bool RUN_DETECT_TRACK_ = true;

--- a/src/WSrtInterface.cpp
+++ b/src/WSrtInterface.cpp
@@ -26,6 +26,9 @@
 
 #include "WSrtInterface.hpp"
 
+// this macro is enabled directly in CMakelists.txt
+#ifdef WSRT_ENABLED
+
 #include <thread>
 #include <chrono>
 #include <queue>
@@ -187,3 +190,5 @@ void WSrt::reset_receivers() {
 }
 
 }
+
+#endif // WSRT_ENABLED

--- a/src/multi_cam.cpp
+++ b/src/multi_cam.cpp
@@ -82,7 +82,7 @@ int main(int argc, char * argv[]) {
 		for (auto & camera : cameras_) {
 
 			// get camera frame
-			if (IS_REALTIME_ == 2) { // To remove when interface shifts
+			#if WSRT_ENABLED // To remove when interface shifts
 				
 				// here is where data from edge cam is passed to the main detection/tracking pipeline
 				wsrt_output edgecam_data;
@@ -124,10 +124,9 @@ int main(int argc, char * argv[]) {
 				// 	{camera->centroids_[i].x + camera->sizes_[i], camera->centroids_[i].y + camera->sizes_[i]}, 150, 3);
 				// }
 				// cv::imshow("SRT raw detections", srt_frame);
-			}
-			else {
+			#else
 				camera->cap_ >> camera->frame_;
-			}
+			#endif
 
 			// check if getting frame was successful
 			if (camera->frame_.empty()) {
@@ -145,7 +144,7 @@ int main(int argc, char * argv[]) {
 
 			if (RUN_DETECT_TRACK_) {
 
-				if (IS_REALTIME_ != 2) { // To remove when interface shifts
+				#if !WSRT_ENABLED // To remove when interface shifts
 
 					// clear detection variable vectors
 					camera->clear_detection_variables();
@@ -169,7 +168,7 @@ int main(int argc, char * argv[]) {
 					}
 
 					}
-				}// Edge Cam Interface is currently before KF/DCF. To be shifted
+				#endif // Edge Cam Interface is currently before KF/DCF. To be shifted
 
 				// apply state estimation filters
 				predict_new_locations_of_tracks(camera);

--- a/src/multi_cam.cpp
+++ b/src/multi_cam.cpp
@@ -158,15 +158,11 @@ int main(int argc, char * argv[]) {
 					// correct for environmental effects
 					apply_env_compensation(camera);
 
-					// apply background subtractor
-					// remove_ground(camera, 0);
-					// remove_ground(camera, 1);
-
 					simple_background_subtraction(camera);
 
 					// get detections
 					if (USE_BLOB_DETECTION) {
-						detect_objects(camera);
+						blob_detection(camera);
 					}
 					else {
 						contour_detection(camera);

--- a/src/multi_cam_detect.cpp
+++ b/src/multi_cam_detect.cpp
@@ -905,12 +905,11 @@ namespace mcmt {
 	 */
 	void close_cameras() {
 		for (int cam_idx = 0; cam_idx < NUM_OF_CAMERAS_; cam_idx++) {
-			if (IS_REALTIME_ == 2) { // To remove when interface shifts
+			#if WSRT_ENABLED // To remove when interface shifts
 				cameras_[cam_idx]->edgecam_cap_->reset_receivers();
-			}
-			else {
+			#else
 				cameras_[cam_idx].get()->cap_.release();
-			}
+			#endif
 			if (IS_REALTIME_) cameras_[cam_idx]->recording_.release();
 		}
 	}

--- a/src/multi_cam_detect.cpp
+++ b/src/multi_cam_detect.cpp
@@ -75,77 +75,6 @@ namespace mcmt {
 	}
 
 	/**
-	 * Simple background subtractor, using MOG2
-	 */
-	void simple_background_subtraction(std::shared_ptr<Camera> & camera) {
-		cv::Mat current_frame = camera->frame_;
-		cv::Mat current_frame_ec = camera->frame_ec_;
-
-		camera->simple_MOG2->apply(current_frame , camera->foreground_mask);
-		camera->foreground_mask.convertTo(camera->masked_[0], CV_8UC1);
-
-		camera->simple_MOG2_ec->apply(current_frame_ec , camera->foreground_mask_ec);
-		camera->foreground_mask_ec.convertTo(camera->masked_[1], CV_8UC1);
-		
-	}
-
-	void contour_detection(std::shared_ptr<Camera> & camera) {
-
-		// Dilate to increase size of contours, making them more visible
-		cv::erode(camera->masked_[0], camera->masked_[0], erode_element, cv::Point(), DILATION_ITER_);
-		cv::dilate(camera->masked_[0], camera->masked_[0], dilate_element, cv::Point(), DILATION_ITER_);
-
-		// Find the contours in current 
-		cv::findContours(camera->masked_[0], camera->current_frame_contours, cv::RETR_TREE, cv::CHAIN_APPROX_SIMPLE);
-		
-		cv::imshow("After erode-dilate", camera->masked_[0]);
-
-		for (int j = 0; j < camera->current_frame_contours.size(); j++) {
-			if (cv::contourArea(camera->current_frame_contours[j]) > SMALLEST_ALLOWED_CONTOUR) {
-				cv::minEnclosingCircle(camera->current_frame_contours[j], camera->contour_center, camera->contour_radius);
-				camera->centroids_.push_back(camera->contour_center);
-				camera->sizes_.push_back(cv::contourArea(camera->current_frame_contours[j]));
-			}
-		}
-
-		// Remove overlapped detections using searching algorithm
-		int search_pointer = 0;
-		for (auto & centroid : camera->centroids_) {
-		
-		}
-		/**
-		// Clear the contours after every search, save original size
-		int original_size = camera->current_frame_contours.size();
-		camera->current_frame_contours.clear();
-
-		// Dilate to increase size of contours, making them more visible for environmental compensation
-		cv::erode(camera->masked_[1], camera->masked_[1], erode_element, cv::Point(), DILATION_ITER_);
-		cv::dilate(camera->masked_[1], camera->masked_[1], dilate_element, cv::Point(), DILATION_ITER_);
-
-		cv::imshow("Env comp after", camera->masked_[1]);
-
-		
-		// Find the contours in enviornmentally compensated, add if no overlap
-		cv::findContours(camera->masked_[1], camera->current_frame_contours, cv::RETR_TREE, cv::CHAIN_APPROX_SIMPLE);
-		
-		for (int k = 0; k < camera->current_frame_contours.size(); k++) {
-			bool valid = true;
-			for (int l = 0; l < original_size; l++ ) {
-				cv::minEnclosingCircle(camera->current_frame_contours[k], camera->contour_center, camera->contour_radius);
-				if (euclideanDist(camera->centroids_[l], camera->contour_center) < 5) {
-					valid = false;
-					break;
-				}
-			}
-			if (valid) {
-				camera->centroids_.push_back(camera->contour_center);
-				camera->sizes_.push_back(cv::contourArea(camera->current_frame_contours[k]));
-			}
-		}
-		**/
-	}
-
-	/**
 	 * Detect objects using Yolov5. Use this for large targets
 	 */
 	void yolo_detection(std::shared_ptr<Camera> & camera) {
@@ -240,51 +169,26 @@ namespace mcmt {
 		// cv::imshow("After sun compensation", camera->frame_ec_);
 	}
 
-	/** 
-	 * This function uses the background subtractor to subtract the history from the current frame.
+	/**
+	 * Simple background subtractor, using MOG2
 	 */
-	void remove_ground(std::shared_ptr<Camera> & camera, int masked_id)	{
+	void simple_background_subtraction(std::shared_ptr<Camera> & camera) {
+		cv::Mat current_frame = camera->frame_;
+		cv::Mat current_frame_ec = camera->frame_ec_;
 
-		cv::Mat masked;
+		camera->simple_MOG2->apply(current_frame , camera->foreground_mask);
+		camera->foreground_mask.convertTo(camera->masked_[0], CV_8UC1);
+
+		camera->simple_MOG2_ec->apply(current_frame_ec , camera->foreground_mask_ec);
+		camera->foreground_mask_ec.convertTo(camera->masked_[1], CV_8UC1);
+		cv::imshow("bg-subtracted", camera->masked_[0]);
 		
-		// Apply contrast and brightness gains
-		// To-do: Explain how the formula for calculating brightness in the 2nd line works
-		cv::convertScaleAbs((masked_id ? camera->frame_ec_ : camera->frame_), masked, 1, (256 - average_brightness(camera) + BRIGHTNESS_GAIN_));
-		
-		// subtract background
-		camera->fgbg_[masked_id]->apply(masked, masked, FGBG_LEARNING_RATE_);
-		masked.convertTo(camera->masked_[masked_id], CV_8UC1);
-
-		if (USE_BG_SUBTRACTOR_){
-			// declare variables
-			std::vector<std::vector<cv::Point>> contours, background_contours;
-
-			// number of iterations determines how close objects need to be to be considered background
-			cv::Mat dilated;
-			cv::dilate(camera->masked_[masked_id], dilated, element_, cv::Point(), int(REMOVE_GROUND_ITER_ * camera->scale_factor_));
-			findContours(dilated, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
-
-			for (auto & it : contours) {
-				float circularity = 4 * M_PI * cv::contourArea(it) / (pow(cv::arcLength(it, true), 2));
-				if (circularity <= BACKGROUND_CONTOUR_CIRCULARITY_) {
-					background_contours.push_back(it);
-				}
-			}
-			
-			// show removed background on raw image frames
-			// cv::Mat bg_removed = masked_id ? camera->frame_ec_.clone() : camera->frame_.clone();
-			// cv::drawContours(bg_removed, background_contours, -1, cv::Scalar(0, 255, 0), 3);
-			// cv::imshow("bg_removed", bg_removed);
-
-			// draw contours on masked frame using solid shape to remove background
-			cv::drawContours(camera->masked_[masked_id], background_contours, -1, cv::Scalar(0, 0, 0), -1);
-		}
 	}
 
 	/**
 	 * This function applies masking operations before performing blob detection
 	 */
-	void detect_objects(std::shared_ptr<Camera> & camera) {
+	void blob_detection(std::shared_ptr<Camera> & camera) {
 		
 		// apply morphological transformation
 		cv::dilate(camera->masked_[0], camera->masked_[0], element_, cv::Point(), DILATION_ITER_);
@@ -320,6 +224,63 @@ namespace mcmt {
 				camera->sizes_.push_back(it.size);
 			}
 		}
+	}
+
+	/**
+	 * This function applies contour detection, an alternative to moving object blob detection
+	 */
+	void contour_detection(std::shared_ptr<Camera> & camera) {
+
+		// Dilate to increase size of contours, making them more visible
+		cv::erode(camera->masked_[0], camera->masked_[0], erode_element, cv::Point(), DILATION_ITER_);
+		cv::dilate(camera->masked_[0], camera->masked_[0], dilate_element, cv::Point(), DILATION_ITER_);
+
+		// Find the contours in current 
+		cv::findContours(camera->masked_[0], camera->current_frame_contours, cv::RETR_TREE, cv::CHAIN_APPROX_SIMPLE);
+
+		for (int j = 0; j < camera->current_frame_contours.size(); j++) {
+			if (cv::contourArea(camera->current_frame_contours[j]) > SMALLEST_ALLOWED_CONTOUR) {
+				cv::minEnclosingCircle(camera->current_frame_contours[j], camera->contour_center, camera->contour_radius);
+				camera->centroids_.push_back(camera->contour_center);
+				camera->sizes_.push_back(cv::contourArea(camera->current_frame_contours[j]));
+			}
+		}
+
+		// Remove overlapped detections using searching algorithm
+		int search_pointer = 0;
+		for (auto & centroid : camera->centroids_) {
+		
+		}
+		/**
+		// Clear the contours after every search, save original size
+		int original_size = camera->current_frame_contours.size();
+		camera->current_frame_contours.clear();
+
+		// Dilate to increase size of contours, making them more visible for environmental compensation
+		cv::erode(camera->masked_[1], camera->masked_[1], erode_element, cv::Point(), DILATION_ITER_);
+		cv::dilate(camera->masked_[1], camera->masked_[1], dilate_element, cv::Point(), DILATION_ITER_);
+
+		cv::imshow("Env comp after", camera->masked_[1]);
+
+		
+		// Find the contours in enviornmentally compensated, add if no overlap
+		cv::findContours(camera->masked_[1], camera->current_frame_contours, cv::RETR_TREE, cv::CHAIN_APPROX_SIMPLE);
+		
+		for (int k = 0; k < camera->current_frame_contours.size(); k++) {
+			bool valid = true;
+			for (int l = 0; l < original_size; l++ ) {
+				cv::minEnclosingCircle(camera->current_frame_contours[k], camera->contour_center, camera->contour_radius);
+				if (euclideanDist(camera->centroids_[l], camera->contour_center) < 5) {
+					valid = false;
+					break;
+				}
+			}
+			if (valid) {
+				camera->centroids_.push_back(camera->contour_center);
+				camera->sizes_.push_back(cv::contourArea(camera->current_frame_contours[k]));
+			}
+		}
+		**/
 	}
 
 	/**


### PR DESCRIPTION
Key changes:

1. Decouple WSrt edge computing code from main code. This allows users who do not need edge computing to avoid installing dependencies such as spdlog, soup, etc...
2. Extensive updates to Readme installation and running instructions - especially how to specify the input parameters
3. Tidy-up of detection code

The WSrt edge computing flag is now specified as "WSRT" in the CMakelists. Set it to ON or OFF to activate/deactivate it. Activating it will toggle the macro WSRT_ENABLED throughout the main code, and tell CMake to compile all WSrt related dependencies